### PR TITLE
test: add a test for the Krb5 authentication

### DIFF
--- a/test/com/trilead/ssh2/KerberosTest.java
+++ b/test/com/trilead/ssh2/KerberosTest.java
@@ -1,0 +1,45 @@
+package com.trilead.ssh2;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/*
+    This is a test class for the Kerberos authentication, it requires an Kerberos environment
+    it was tested with the environment defined here https://github.com/criteo/kerberos-docker.git
+
+    "KRB5_HOST=krb5-service-instance-com"
+    "KRB5_USER=bob"
+
+    @author Kuisathaverat
+ */
+public class KerberosTest {
+
+    @Before
+    public void beforeMethod() {
+        org.junit.Assume.assumeTrue(System.getenv("KRB5_HOST") != null);
+        org.junit.Assume.assumeTrue(System.getenv("KRB5_USER") != null);
+    }
+
+    @Test
+    public void testConnection() throws IOException {
+        String host = System.getenv("KRB5_HOST");
+        String user = System.getenv("KRB5_USER");
+        Connection con = new Connection(host);
+        con.connect();
+        assertTrue(con.authenticateWithGssapiWithMic(user));
+    }
+
+    @Test
+    public void testConnectionFAIL() throws IOException {
+        String host = System.getenv("KRB5_HOST");
+        String user = System.getenv("KRB5_USER");
+        Connection con = new Connection(host);
+        con.connect();
+        assertFalse(con.authenticateWithGssapiWithMic(user + "NotExists"));
+    }
+}

--- a/test/krb5_test.sh
+++ b/test/krb5_test.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+#
+# The script is used to provision a Kerberos environment an run some authentication tests againts it.
+# it use the enviroment defined in https://github.com/criteo/kerberos-docker.git
+# Author: Kuisathaverat
+#
 
 git clone https://github.com/criteo/kerberos-docker.git
 cd kerberos-docker

--- a/test/krb5_test.sh
+++ b/test/krb5_test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+git clone https://github.com/criteo/kerberos-docker.git
+cd kerberos-docker
+make install
+cd ..
+docker cp . krb5-machine-instance-com:/root/trilead-ssh2
+docker exec -it -w "/root/trilead-ssh2" -e "KRB5_HOST=krb5-service-instance-com" -e "KRB5_USER=bob" krb5-machine-instance-com mvn clean test -Dtest=KerberosTest


### PR DESCRIPTION
the tests check a valid user and invalid user, to run the tests, it needs to deploy a Kerberos environment, the script test/krb5_test.sh make all the work, the tests only run when KRB5_HOST and KRB5_USER are defined.